### PR TITLE
Activate extension on start up

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "git"
   ],
   "activationEvents": [
-    "onStartupFinished"
+    "*"
   ],
   "main": "./out/extension.js",
   "contributes": {


### PR DESCRIPTION
This PR reverts extension activation events from `onStartupFinished` to `*`.