### PR TITLE
Add “GitDoc: Commit” command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ When you install the `GitDoc` extension, the following commands are contributed 
 
 - `GitDoc: Disable` - Disables auto-commits. This command is only visible when GitDoc is enabled.
 
+- `GitDoc: Commit` - Manually commits changes. This command allows you to trigger a commit without waiting for the auto-commit interval.
+
 ## Contributed Settings
 
 The following settings enable you to customize the default behavior of `GitDoc`:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
       {
         "command": "gitdoc.undoVersion",
         "title": "Undo Version"
+      },
+      {
+        "command": "gitdoc.commit",
+        "title": "Commit",
+        "category": "GitDoc"
       }
     ],
     "configuration": {
@@ -170,6 +175,10 @@
         {
           "command": "gitdoc.undoVersion",
           "when": "false"
+        },
+        {
+          "command": "gitdoc.commit",
+          "when": "gitdoc:enabled"
         }
       ],
       "timeline/item/context": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -67,4 +67,11 @@ export function registerCommands(context: vscode.ExtensionContext) {
 
     await commit(git?.repositories[0]!);
   });
+
+  registerCommand("commit", async () => {
+    const git = await getGitApi();
+    if (git && git.repositories.length > 0) {
+      await commit(git.repositories[0]);
+    }
+  });
 }


### PR DESCRIPTION
Fixes #77

This PR introduces a new “GitDoc: Commit” command, that is available when GitDoc is enabled, and allows you to trigger a manual commit (as opposed to waiting for the next interval).

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lostintangent/gitdoc/issues/77?shareId=52c9be80-f6a4-447e-b642-936b2469828e).