### PR TITLE
Add Support for using --no-verify in auto commits to ignore Git-Hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
           "default": "**/*",
           "description": "Specifies a glob that indicates the specific files that should be automatically committed."
         },
+        "gitdoc.noVerify": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies whether to ignore configured Git-Hooks"
+        },
         "gitdoc.pullOnOpen": {
           "type": "boolean",
           "default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,9 @@ export default {
   get filePattern() {
     return config().get("filePattern", "**/*");
   },
+  get noVerify(): boolean {
+    return config().get("noVerify", false);
+  },
   get pullOnOpen() {
     return config().get("pullOnOpen", true);
   },

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 
 interface CommitOptions {
   all?: boolean | "tracked";
+  noVerify?: boolean;
 }
 
 interface Branch {

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -116,8 +116,7 @@ export async function commit(repository: Repository, message?: string) {
 
       const commitMessage =
         message || currentTime.toFormat(config.commitMessageFormat);
-
-      await repository.commit(commitMessage);
+      await repository.commit(commitMessage, { noVerify: config.noVerify });
 
       delete process.env.GIT_AUTHOR_DATE;
       delete process.env.GIT_COMMITTER_DATE;


### PR DESCRIPTION
Fixes #81 

This PR adds a new Option in the Extension Settings to enable or disable Git-Hooks. It is using the git API of VS Code with ne noVerify gitOption.