### PR TITLE
Status bar icon toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.4 (Unreleased)
+
+- Added new `gitdoc.alwaysShowStatusBarIcon` setting to optionally keep the status bar icon visible when GitDoc is disabled (#89), and improved icon display to properly indicate when viewing files that don't match the file pattern
+- Added new `GitDoc: Toggle Status Bar Icon Visibility` command to quickly toggle the status bar icon visibility
+- Fixed issue where GitDoc was inactive on codespace start despite being enabled in settings (#90)
+
 ## v0.2.3 (12/26/2024)
 
 - Introduced a new `GitDoc > AI: Use Emojis` setting, to alloq prepending AI-generated commit messages with an emoji.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,13 @@ If you've made a bunch of changes to a file, and want to restore an older versio
 
 ## Status Bar
 
-Whenever `GitDoc` is enabled, it will contribute a status bar item to your status bar. This simply indicates that it's enabled, and makes it easier for you to know which "versioning mode" you're in (auto-commit vs. manual commit). Additionally, if you enable [auto-pushing](#auto-pushing), then the status bar will indicate when it's syncing your commits with your repo. If you click the `GitDoc` status bar item, this will disable `GitDoc`. This allows you to easily enable GitDoc for a period of time, and then quickly turn it off.
+Whenever `GitDoc` is installed, it will contribute a status bar item to your status bar. The status bar icon changes based on the current state:
+
+- When disabled: Shows a "sync-ignored" icon ($(sync-ignored))
+- When enabled and viewing a matching file: Shows a "mirror" icon ($(mirror))
+- When enabled but viewing a non-matching file: Shows a "mirror" icon with a circle-slash next to it ($(mirror) $(circle-slash))
+
+Additionally, if you enable [auto-pushing](#auto-pushing), then the status bar will indicate when it's syncing your commits with your repo. If you click the `GitDoc` status bar item, this will toggle between enabled and disabled states. This allows you to easily enable GitDoc for a period of time, and then quickly turn it off.
 
 ## Contributed Commands
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Auto-committing is useful for tracking unique versions, however, depending on ho
 
 <img width="700px" src="https://user-images.githubusercontent.com/116461/79668805-3c84ab00-816c-11ea-9ec9-845650b999b8.gif" />
 
-> Demystification: Behind the scenes, this command performs a `git reset --soft`, starting at the commit _before_ the selected one. It then runs `git commit -m <message>`, where `message` is the string you specified. This preserves your working directory/index, while "rewritting" the commit history.
+> Demystification: Behind the scenes, this command performs a `git reset --soft`, starting at the commit _before_ the selected one. It then runs `git commit -m <message>`, where `message` is the string you specified. This preserves your working directory/index, while "rewritten" the commit history.
 
 ## Undoing versions
 
@@ -92,6 +92,8 @@ When you install the `GitDoc` extension, the following commands are contributed 
 - `GitDoc: Enable` - Enables auto-commits. This command is only visible when GitDoc isn't already enabled.
 
 - `GitDoc: Disable` - Disables auto-commits. This command is only visible when GitDoc is enabled.
+
+- `GitDoc: Toggle Status Bar Icon Visibility` - Toggles whether the GitDoc status bar icon is always visible or only visible when GitDoc is enabled. This provides a quick way to toggle the `gitdoc.alwaysShowStatusBarIcon` setting.
 
 - `GitDoc: Commit` - Manually commits changes. This command allows you to trigger a commit without waiting for the auto-commit interval.
 
@@ -136,3 +138,14 @@ The following settings enable you to customize the default behavior of `GitDoc`:
 - `GitDoc > AI: Custom Instructions` - Specifies custom instructions to use when generating commit messages (e.g. use conventional commit syntax, use emojis). This setting only applies when `GitDoc > AI: Enabled` is set to `true`."
 
 - `GitDoc > AI: Use Emojis` - Specifies whether to prepend AI-generated commit messages with an emoji. This setting only applies when `GitDoc > AI: Enabled` is set to `true`. Defaults to `false`.
+
+## Configuration Settings
+
+You can customize `GitDoc`'s behavior using the following settings:
+
+| Setting                          | Description                                                                                                                                                                                                                    |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `gitdoc.enabled`                 | Specifies whether to automatically create a commit each time you save a file.                                                                                                                                                  |
+| `gitdoc.alwaysShowStatusBarIcon` | When true, the status bar icon is always visible (even when GitDoc is disabled), with its appearance changing to indicate the current state. When false (default), the status bar icon is only visible when GitDoc is enabled. |
+| `gitdoc.autoCommitDelay`         | Specifies the number of milliseconds to wait before automatically committing changes.                                                                                                                                          |
+| `gitdoc.filePattern`             | Specifies a glob pattern that indicates the specific files that should be automatically committed.                                                                                                                             |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitdoc",
-  "version": "0.1.0",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gitdoc",
-      "version": "0.1.0",
+      "version": "0.2.3",
       "dependencies": {
         "luxon": "^2.0.2",
         "minimatch": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "displayName": "GitDoc",
   "publisher": "vsls-contrib",
   "icon": "images/icon.png",
-  "description": "Automatically commit/push/pull changes on save, so you can edit a Git repo like a multi-file, versioned document.",
-  "version": "0.2.3",
+  "description": "A continuous, frictionless, background-saving experience that intelligently commits your changes.",
+  "version": "0.2.4",
   "extensionKind": [
     "workspace"
   ],
@@ -38,6 +38,11 @@
       {
         "command": "gitdoc.enable",
         "title": "Enable",
+        "category": "GitDoc"
+      },
+      {
+        "command": "gitdoc.toggleStatusBarIcon",
+        "title": "Toggle Status Bar Icon Visibility",
         "category": "GitDoc"
       },
       {
@@ -95,12 +100,17 @@
         "gitdoc.autoPushDelay": {
           "type": "number",
           "default": 30000,
-          "markdownDescription": "Controls the delay in ms after which any commits are automatically pushed. Only applies when `GitDoc: Auto Push` is set to `afterDelay`."
+          "description": "Specifies the number of milliseconds to wait before automatically pushing changes to a remote branch. This setting only applies when 'GitDoc > Auto Push' is set to 'After Delay'."
+        },
+        "gitdoc.alwaysShowStatusBarIcon": {
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies whether to always show the status bar icon, even when GitDoc is disabled. When true, the icon appearance will change to indicate whether GitDoc is enabled or disabled."
         },
         "gitdoc.commitMessageFormat": {
           "type": "string",
-          "default": "ff",
-          "markdownDescription": "Specifies the date/time format string (using Luxon) to use when generating auto-commit messages. Views [the docs](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) for more details."
+          "default": "lll",
+          "markdownDescription": "Specifies the format to use for auto-generated commit messages. This setting only applies when `GitDoc > AI: Enabled` is set to `false`. By default, it uses the [Luxon date format](https://moment.github.io/luxon/#/formatting)."
         },
         "gitdoc.commitValidationLevel": {
           "type": "string",
@@ -195,6 +205,10 @@
         {
           "command": "gitdoc.enable",
           "when": "gitOpenRepositoryCount != 0 && !gitdoc:enabled"
+        },
+        {
+          "command": "gitdoc.toggleStatusBarIcon",
+          "when": "gitOpenRepositoryCount != 0"
         },
         {
           "command": "gitdoc.restoreVersion",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { EXTENSION_NAME } from "./constants";
 import { getGitApi } from "./git";
 import { updateContext } from "./utils";
-import { commit } from "./watcher";
+import { commit, updateStatusBarItem } from "./watcher";
 
 interface GitTimelineItem {
   message: string;
@@ -19,6 +19,26 @@ export function registerCommands(context: vscode.ExtensionContext) {
 
   registerCommand("enable", updateContext.bind(null, true));
   registerCommand("disable", updateContext.bind(null, false));
+
+  registerCommand("toggleStatusBarIcon", async () => {
+    // Get the current setting value
+    const currentValue = vscode.workspace.getConfiguration("gitdoc").get("alwaysShowStatusBarIcon", false);
+
+    // Toggle the setting
+    await vscode.workspace.getConfiguration("gitdoc").update(
+      "alwaysShowStatusBarIcon",
+      !currentValue,
+      vscode.ConfigurationTarget.Global
+    );
+
+    // Show notification to the user
+    vscode.window.showInformationMessage(
+      `GitDoc: Status bar icon will ${!currentValue ? "always" : "only"} be visible ${!currentValue ? "even when disabled" : "when enabled"}`
+    );
+
+    // Update the status bar immediately
+    updateStatusBarItem(vscode.window.activeTextEditor);
+  });
 
   registerCommand("restoreVersion", async (item: GitTimelineItem) => {
     if (!vscode.window.activeTextEditor) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,9 @@ export default {
   get autoPushDelay(): number {
     return config().get("autoPushDelay", DEFAULT_DELAY_MS);
   },
+  get alwaysShowStatusBarIcon(): boolean {
+    return config().get("alwaysShowStatusBarIcon", false);
+  },
   get commitMessageFormat(): string {
     return config().get("commitMessageFormat", "lll");
   },

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -262,6 +262,7 @@ export function updateStatusBarItem(editor: vscode.TextEditor | undefined) {
   // Icon states:
   // - Enabled + Matching file: Show mirror
   // - Enabled + Non-matching file: Show mirror with circle-slash overlay using ~
+  // var icon = "$(mirror)";
   const icon = isMatchingFile ? "$(mirror)" : "$(mirror) $(circle-slash)";
   
   statusBarItem.text = `${icon}${suffix}`;


### PR DESCRIPTION
Hi @lostintangent, hope you're doing well. GitDoc is a great tool, but I wanted a feature to have it always show the status bar icon rather than it disappearing when disabled (#89 ). In fixing that, I also ended up fixing #90 as it affected the icons being shown. I handled icons for matching the File Patterns too. Have a look and let me know what you think?

Cheers, 

Tom