### PR TITLE
Support multi-rooted workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitdoc",
-  "version": "0.1.0",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gitdoc",
-      "version": "0.1.0",
+      "version": "0.2.3",
       "dependencies": {
         "luxon": "^2.0.2",
         "minimatch": "^3.0.4",


### PR DESCRIPTION
Changes Made

- `src/extension.ts`:
  - Changed from single `watcher` to array of `watchers` to handle multiple repositories
  - Updated `checkEnabled()` to iterate through all repositories and check branch eligibility
  - Modified `deactivate()` to commit changes in all repositories on close
- `src/watcher.ts`:
  - Updated `watchForChanges()` to set up change listeners for all repositories
  - Modified periodic push/pull operations to handle all repositories
- `src/commands.ts`:
  - All commands now use `git.getRepository(uri)` to find the appropriate repository for the active file
  - Added error handling when no repository is found for a file
  - The manual commit command targets the active file's repository or falls back to all repositories

Notes:

1. Commands operate on the repository containing the currently active file
2. Graceful degradation: If no active file, operations target all repositories
3. Users get a message when no git repository is found
4. Single-repo workspaces work as before